### PR TITLE
Add FanCI module in C++ (with AP1roG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ cleandeps:
 # ------------
 
 compile_flags.txt:
-	echo $(CFLAGS) | tr ' ' '\n' > $(@)
+	echo "$(CFLAGS)" | tr ' ' '\n' > $(@)
 
 pyci/src/%.o: pyci/src/%.cpp pyci/include/pyci.h $(DEPS)
 	$(CXX) $(CFLAGS) $(DEFS) -c $(<) -o $(@)

--- a/pyci/fanci/test/test_ap1rog.py
+++ b/pyci/fanci/test/test_ap1rog.py
@@ -9,7 +9,6 @@ import pyci
 
 from pyci.fanci import AP1roG
 from pyci.fanci.fanci import fill_wavefunction
-from pyci.fanci.apig import permanent
 from pyci.fanci.test import find_datafile, assert_deriv
 
 
@@ -136,20 +135,3 @@ def test_ap1rog_init_defaults():
     assert test.nvir_up == nbasis - nocc
     assert test.nvir_dn == nbasis - nocc
     assert test.pspace.shape[0] == 9
-
-
-def test_ap1rog_permanent():
-    matrix = np.arange(1, 65, dtype=float)
-    answers = [
-        1.0,
-        1.0,
-        10.0,
-        450.0,
-        55456.0,
-        14480700.0,
-        6878394720.0,
-        5373548250000.0,
-        6427291156586496.0,
-    ]
-    for i, answer in enumerate(answers):
-        assert permanent(matrix[: i ** 2].reshape(i, i)) == answer

--- a/pyci/fanci/test/test_apig.py
+++ b/pyci/fanci/test/test_apig.py
@@ -7,7 +7,6 @@ import pytest
 import pyci
 
 from pyci.fanci import APIG
-from pyci.fanci.apig import permanent
 from pyci.fanci.test import find_datafile, assert_deriv
 
 
@@ -67,8 +66,8 @@ def test_apig_compute_overlap_deriv(dummy_system):
     ham, nocc, params = dummy_system
     apig = APIG(ham, nocc, nproj=None)
 
-    f = lambda x: apig.compute_overlap(x, apig.sspace)
-    j = lambda x: apig.compute_overlap_deriv(x, apig.sspace)
+    f = lambda x: apig.compute_overlap(x)
+    j = lambda x: apig.compute_overlap_deriv(x)
     origin = np.random.rand(params[:-1].shape[0])
     assert_deriv(f, j, origin)
 
@@ -80,7 +79,7 @@ def test_apig_compute_objective(dummy_system):
 
     objective = apig.compute_objective(params)
     op = pyci.sparse_op(apig.ham, apig.wfn, nproj, symmetric=False)
-    ovlp = apig.compute_overlap(params[:-1], apig.sspace)
+    ovlp = apig.compute_overlap(params[:-1])
     answer = op(ovlp) - params[-1] * ovlp[:nproj]
     assert np.allclose(objective, answer)
 
@@ -152,20 +151,3 @@ def test_apig_init_defaults():
     assert test.nvir_up == nbasis - nocc
     assert test.nvir_dn == nbasis - nocc
     assert test.pspace.shape[0] == 13
-
-
-def test_apig_permanent():
-    matrix = np.arange(1, 65, dtype=float)
-    answers = [
-        1.0,
-        1.0,
-        10.0,
-        450.0,
-        55456.0,
-        14480700.0,
-        6878394720.0,
-        5373548250000.0,
-        6427291156586496.0,
-    ]
-    for i, answer in enumerate(answers):
-        assert permanent(matrix[: i ** 2].reshape(i, i)) == answer

--- a/pyci/include/SpookyV2.h
+++ b/pyci/include/SpookyV2.h
@@ -1,0 +1,299 @@
+//
+// SpookyHash: a 128-bit noncryptographic hash function
+// By Bob Jenkins, public domain
+//   Oct 31 2010: alpha, framework + SpookyHash::Mix appears right
+//   Oct 31 2011: alpha again, Mix only good to 2^^69 but rest appears right
+//   Dec 31 2011: beta, improved Mix, tested it for 2-bit deltas
+//   Feb  2 2012: production, same bits as beta
+//   Feb  5 2012: adjusted definitions of uint* to be more portable
+//   Mar 30 2012: 3 bytes/cycle, not 4.  Alpha was 4 but wasn't thorough enough.
+//   August 5 2012: SpookyV2 (different results)
+// 
+// Up to 3 bytes/cycle for long messages.  Reasonably fast for short messages.
+// All 1 or 2 bit deltas achieve avalanche within 1% bias per output bit.
+//
+// This was developed for and tested on 64-bit x86-compatible processors.
+// It assumes the processor is little-endian.  There is a macro
+// controlling whether unaligned reads are allowed (by default they are).
+// This should be an equally good hash on big-endian machines, but it will
+// compute different results on them than on little-endian machines.
+//
+// Google's CityHash has similar specs to SpookyHash, and CityHash is faster
+// on new Intel boxes.  MD4 and MD5 also have similar specs, but they are orders
+// of magnitude slower.  CRCs are two or more times slower, but unlike 
+// SpookyHash, they have nice math for combining the CRCs of pieces to form 
+// the CRCs of wholes.  There are also cryptographic hashes, but those are even 
+// slower than MD5.
+//
+
+#include <stddef.h>
+
+#ifdef _MSC_VER
+# define INLINE __forceinline
+  typedef  unsigned __int64 uint64;
+  typedef  unsigned __int32 uint32;
+  typedef  unsigned __int16 uint16;
+  typedef  unsigned __int8  uint8;
+#else
+# include <stdint.h>
+# define INLINE inline
+  typedef  uint64_t  uint64;
+  typedef  uint32_t  uint32;
+  typedef  uint16_t  uint16;
+  typedef  uint8_t   uint8;
+#endif
+
+
+class SpookyHash
+{
+public:
+    //
+    // SpookyHash: hash a single message in one call, produce 128-bit output
+    //
+    static void Hash128(
+        const void *message,  // message to hash
+        size_t length,        // length of message in bytes
+        uint64 *hash1,        // in/out: in seed 1, out hash value 1
+        uint64 *hash2);       // in/out: in seed 2, out hash value 2
+
+    //
+    // Hash64: hash a single message in one call, return 64-bit output
+    //
+    static uint64 Hash64(
+        const void *message,  // message to hash
+        size_t length,        // length of message in bytes
+        uint64 seed)          // seed
+    {
+        uint64 hash1 = seed;
+        Hash128(message, length, &hash1, &seed);
+        return hash1;
+    }
+
+    //
+    // Hash32: hash a single message in one call, produce 32-bit output
+    //
+    static uint32 Hash32(
+        const void *message,  // message to hash
+        size_t length,        // length of message in bytes
+        uint32 seed)          // seed
+    {
+        uint64 hash1 = seed, hash2 = seed;
+        Hash128(message, length, &hash1, &hash2);
+        return (uint32)hash1;
+    }
+
+    //
+    // Init: initialize the context of a SpookyHash
+    //
+    void Init(
+        uint64 seed1,       // any 64-bit value will do, including 0
+        uint64 seed2);      // different seeds produce independent hashes
+    
+    //
+    // Update: add a piece of a message to a SpookyHash state
+    //
+    void Update(
+        const void *message,  // message fragment
+        size_t length);       // length of message fragment in bytes
+
+
+    //
+    // Final: compute the hash for the current SpookyHash state
+    //
+    // This does not modify the state; you can keep updating it afterward
+    //
+    // The result is the same as if SpookyHash() had been called with
+    // all the pieces concatenated into one message.
+    //
+    void Final(
+        uint64 *hash1,    // out only: first 64 bits of hash value.
+        uint64 *hash2);   // out only: second 64 bits of hash value.
+
+    //
+    // left rotate a 64-bit value by k bytes
+    //
+    static INLINE uint64 Rot64(uint64 x, int k)
+    {
+        return (x << k) | (x >> (64 - k));
+    }
+
+    //
+    // This is used if the input is 96 bytes long or longer.
+    //
+    // The internal state is fully overwritten every 96 bytes.
+    // Every input bit appears to cause at least 128 bits of entropy
+    // before 96 other bytes are combined, when run forward or backward
+    //   For every input bit,
+    //   Two inputs differing in just that input bit
+    //   Where "differ" means xor or subtraction
+    //   And the base value is random
+    //   When run forward or backwards one Mix
+    // I tried 3 pairs of each; they all differed by at least 212 bits.
+    //
+    static INLINE void Mix(
+        const uint64 *data, 
+        uint64 &s0, uint64 &s1, uint64 &s2, uint64 &s3,
+        uint64 &s4, uint64 &s5, uint64 &s6, uint64 &s7,
+        uint64 &s8, uint64 &s9, uint64 &s10,uint64 &s11)
+    {
+      s0 += data[0];    s2 ^= s10;    s11 ^= s0;    s0 = Rot64(s0,11);    s11 += s1;
+      s1 += data[1];    s3 ^= s11;    s0 ^= s1;    s1 = Rot64(s1,32);    s0 += s2;
+      s2 += data[2];    s4 ^= s0;    s1 ^= s2;    s2 = Rot64(s2,43);    s1 += s3;
+      s3 += data[3];    s5 ^= s1;    s2 ^= s3;    s3 = Rot64(s3,31);    s2 += s4;
+      s4 += data[4];    s6 ^= s2;    s3 ^= s4;    s4 = Rot64(s4,17);    s3 += s5;
+      s5 += data[5];    s7 ^= s3;    s4 ^= s5;    s5 = Rot64(s5,28);    s4 += s6;
+      s6 += data[6];    s8 ^= s4;    s5 ^= s6;    s6 = Rot64(s6,39);    s5 += s7;
+      s7 += data[7];    s9 ^= s5;    s6 ^= s7;    s7 = Rot64(s7,57);    s6 += s8;
+      s8 += data[8];    s10 ^= s6;    s7 ^= s8;    s8 = Rot64(s8,55);    s7 += s9;
+      s9 += data[9];    s11 ^= s7;    s8 ^= s9;    s9 = Rot64(s9,54);    s8 += s10;
+      s10 += data[10];    s0 ^= s8;    s9 ^= s10;    s10 = Rot64(s10,22);    s9 += s11;
+      s11 += data[11];    s1 ^= s9;    s10 ^= s11;    s11 = Rot64(s11,46);    s10 += s0;
+    }
+
+    //
+    // Mix all 12 inputs together so that h0, h1 are a hash of them all.
+    //
+    // For two inputs differing in just the input bits
+    // Where "differ" means xor or subtraction
+    // And the base value is random, or a counting value starting at that bit
+    // The final result will have each bit of h0, h1 flip
+    // For every input bit,
+    // with probability 50 +- .3%
+    // For every pair of input bits,
+    // with probability 50 +- 3%
+    //
+    // This does not rely on the last Mix() call having already mixed some.
+    // Two iterations was almost good enough for a 64-bit result, but a
+    // 128-bit result is reported, so End() does three iterations.
+    //
+    static INLINE void EndPartial(
+        uint64 &h0, uint64 &h1, uint64 &h2, uint64 &h3,
+        uint64 &h4, uint64 &h5, uint64 &h6, uint64 &h7, 
+        uint64 &h8, uint64 &h9, uint64 &h10,uint64 &h11)
+    {
+        h11+= h1;    h2 ^= h11;   h1 = Rot64(h1,44);
+        h0 += h2;    h3 ^= h0;    h2 = Rot64(h2,15);
+        h1 += h3;    h4 ^= h1;    h3 = Rot64(h3,34);
+        h2 += h4;    h5 ^= h2;    h4 = Rot64(h4,21);
+        h3 += h5;    h6 ^= h3;    h5 = Rot64(h5,38);
+        h4 += h6;    h7 ^= h4;    h6 = Rot64(h6,33);
+        h5 += h7;    h8 ^= h5;    h7 = Rot64(h7,10);
+        h6 += h8;    h9 ^= h6;    h8 = Rot64(h8,13);
+        h7 += h9;    h10^= h7;    h9 = Rot64(h9,38);
+        h8 += h10;   h11^= h8;    h10= Rot64(h10,53);
+        h9 += h11;   h0 ^= h9;    h11= Rot64(h11,42);
+        h10+= h0;    h1 ^= h10;   h0 = Rot64(h0,54);
+    }
+
+    static INLINE void End(
+        const uint64 *data, 
+        uint64 &h0, uint64 &h1, uint64 &h2, uint64 &h3,
+        uint64 &h4, uint64 &h5, uint64 &h6, uint64 &h7, 
+        uint64 &h8, uint64 &h9, uint64 &h10,uint64 &h11)
+    {
+        h0 += data[0];   h1 += data[1];   h2 += data[2];   h3 += data[3];
+        h4 += data[4];   h5 += data[5];   h6 += data[6];   h7 += data[7];
+        h8 += data[8];   h9 += data[9];   h10 += data[10]; h11 += data[11];
+        EndPartial(h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+        EndPartial(h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+        EndPartial(h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+    }
+
+    //
+    // The goal is for each bit of the input to expand into 128 bits of 
+    //   apparent entropy before it is fully overwritten.
+    // n trials both set and cleared at least m bits of h0 h1 h2 h3
+    //   n: 2   m: 29
+    //   n: 3   m: 46
+    //   n: 4   m: 57
+    //   n: 5   m: 107
+    //   n: 6   m: 146
+    //   n: 7   m: 152
+    // when run forwards or backwards
+    // for all 1-bit and 2-bit diffs
+    // with diffs defined by either xor or subtraction
+    // with a base of all zeros plus a counter, or plus another bit, or random
+    //
+    static INLINE void ShortMix(uint64 &h0, uint64 &h1, uint64 &h2, uint64 &h3)
+    {
+        h2 = Rot64(h2,50);  h2 += h3;  h0 ^= h2;
+        h3 = Rot64(h3,52);  h3 += h0;  h1 ^= h3;
+        h0 = Rot64(h0,30);  h0 += h1;  h2 ^= h0;
+        h1 = Rot64(h1,41);  h1 += h2;  h3 ^= h1;
+        h2 = Rot64(h2,54);  h2 += h3;  h0 ^= h2;
+        h3 = Rot64(h3,48);  h3 += h0;  h1 ^= h3;
+        h0 = Rot64(h0,38);  h0 += h1;  h2 ^= h0;
+        h1 = Rot64(h1,37);  h1 += h2;  h3 ^= h1;
+        h2 = Rot64(h2,62);  h2 += h3;  h0 ^= h2;
+        h3 = Rot64(h3,34);  h3 += h0;  h1 ^= h3;
+        h0 = Rot64(h0,5);   h0 += h1;  h2 ^= h0;
+        h1 = Rot64(h1,36);  h1 += h2;  h3 ^= h1;
+    }
+
+    //
+    // Mix all 4 inputs together so that h0, h1 are a hash of them all.
+    //
+    // For two inputs differing in just the input bits
+    // Where "differ" means xor or subtraction
+    // And the base value is random, or a counting value starting at that bit
+    // The final result will have each bit of h0, h1 flip
+    // For every input bit,
+    // with probability 50 +- .3% (it is probably better than that)
+    // For every pair of input bits,
+    // with probability 50 +- .75% (the worst case is approximately that)
+    //
+    static INLINE void ShortEnd(uint64 &h0, uint64 &h1, uint64 &h2, uint64 &h3)
+    {
+        h3 ^= h2;  h2 = Rot64(h2,15);  h3 += h2;
+        h0 ^= h3;  h3 = Rot64(h3,52);  h0 += h3;
+        h1 ^= h0;  h0 = Rot64(h0,26);  h1 += h0;
+        h2 ^= h1;  h1 = Rot64(h1,51);  h2 += h1;
+        h3 ^= h2;  h2 = Rot64(h2,28);  h3 += h2;
+        h0 ^= h3;  h3 = Rot64(h3,9);   h0 += h3;
+        h1 ^= h0;  h0 = Rot64(h0,47);  h1 += h0;
+        h2 ^= h1;  h1 = Rot64(h1,54);  h2 += h1;
+        h3 ^= h2;  h2 = Rot64(h2,32);  h3 += h2;
+        h0 ^= h3;  h3 = Rot64(h3,25);  h0 += h3;
+        h1 ^= h0;  h0 = Rot64(h0,63);  h1 += h0;
+    }
+    
+private:
+
+    //
+    // Short is used for messages under 192 bytes in length
+    // Short has a low startup cost, the normal mode is good for long
+    // keys, the cost crossover is at about 192 bytes.  The two modes were
+    // held to the same quality bar.
+    // 
+    static void Short(
+        const void *message,  // message (array of bytes, not necessarily aligned)
+        size_t length,        // length of message (in bytes)
+        uint64 *hash1,        // in/out: in the seed, out the hash value
+        uint64 *hash2);       // in/out: in the seed, out the hash value
+
+    // number of uint64's in internal state
+    static const size_t sc_numVars = 12;
+
+    // size of the internal state
+    static const size_t sc_blockSize = sc_numVars*8;
+
+    // size of buffer of unhashed data, in bytes
+    static const size_t sc_bufSize = 2*sc_blockSize;
+
+    //
+    // sc_const: a constant which:
+    //  * is not zero
+    //  * is odd
+    //  * is a not-very-regular mix of 1's and 0's
+    //  * does not need any other special mathematical properties
+    //
+    static const uint64 sc_const = 0xdeadbeefdeadbeefLL;
+
+    uint64 m_data[2*sc_numVars];   // unhashed data, for partial messages
+    uint64 m_state[sc_numVars];  // internal state of the hash
+    size_t m_length;             // total length of the input so far
+    uint8  m_remainder;          // length of unhashed data stashed in m_data
+};
+
+
+

--- a/pyci/include/pyci.h
+++ b/pyci/include/pyci.h
@@ -39,9 +39,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
-#include <clhash.h>
-
 #include <parallel_hashmap/phmap.h>
+
+#include <SpookyV2.h>
 
 #include <sort_with_arg.h>
 
@@ -116,6 +116,17 @@ inline int Ctz(const unsigned long long t) {
     return __builtin_ctzll(t);
 }
 
+/* Hash function. */
+
+typedef std::pair<ulong, ulong> Hash;
+
+template<typename T, typename U>
+Hash spookyhash(T length, const U *data) {
+    Hash h(0x23a23cf5033c3c81UL, 0xb3816f6a2c68e530UL);
+    SpookyHash::Hash128(reinterpret_cast<const void *>(data), length * sizeof(U), &h.first, &h.second);
+    return h;
+}
+
 /* Vector template types. */
 
 template<typename T>
@@ -164,9 +175,6 @@ struct SparseOp;
 /* Number of threads global variable. */
 
 extern long g_number_threads;
-
-/* clhash global struct. */
-extern clhasher hasher;
 
 /* PyCI routines. */
 
@@ -293,7 +301,7 @@ public:
 
 protected:
     AlignedVector<ulong> dets;
-    HashMap<ulong, long> dict;
+    HashMap<Hash, long> dict;
 
 public:
     Wfn(const Wfn &);
@@ -358,15 +366,15 @@ public:
 
     long index_det(const ulong *) const;
 
-    long index_det_from_rank(const ulong) const;
+    long index_det_from_rank(const Hash) const;
 
     void copy_det(const long, ulong *) const;
 
-    ulong rank_det(const ulong *) const;
+    Hash rank_det(const ulong *) const;
 
     long add_det(const ulong *);
 
-    long add_det_with_rank(const ulong *, const ulong);
+    long add_det_with_rank(const ulong *, const Hash);
 
     long add_det_from_occs(const long *);
 
@@ -388,7 +396,7 @@ public:
 
     long py_index_det(const Array<ulong>) const;
 
-    ulong py_rank_det(const Array<ulong>) const;
+    Hash py_rank_det(const Array<ulong>) const;
 
     long py_add_det(const Array<ulong>);
 
@@ -443,15 +451,15 @@ public:
 
     long index_det(const ulong *) const;
 
-    long index_det_from_rank(const ulong) const;
+    long index_det_from_rank(const Hash) const;
 
     void copy_det(const long, ulong *) const;
 
-    ulong rank_det(const ulong *) const;
+    Hash rank_det(const ulong *) const;
 
     long add_det(const ulong *);
 
-    long add_det_with_rank(const ulong *, const ulong);
+    long add_det_with_rank(const ulong *, const Hash);
 
     long add_det_from_occs(const long *);
 
@@ -473,7 +481,7 @@ public:
 
     long py_index_det(const Array<ulong>) const;
 
-    ulong py_rank_det(const Array<ulong>) const;
+    Hash py_rank_det(const Array<ulong>) const;
 
     long py_add_det(const Array<ulong>);
 

--- a/pyci/include/pyci.h
+++ b/pyci/include/pyci.h
@@ -765,4 +765,36 @@ public:
     virtual void d_overlap(const size_t, const double *x, double *y);
 };
 
+class APIGObjective : public Objective<DOCIWfn> {
+public:
+    using Objective<DOCIWfn>::nproj;
+    using Objective<DOCIWfn>::nconn;
+    using Objective<DOCIWfn>::nparam;
+    using Objective<DOCIWfn>::ovlp;
+    using Objective<DOCIWfn>::d_ovlp;
+
+    std::size_t nrow;
+    std::size_t ncol;
+    std::vector<std::size_t> part_list;
+
+public:
+    APIGObjective(const SparseOp &, const DOCIWfn &,
+                    const std::size_t = 0UL, const long * = nullptr, const double * = nullptr,
+                    const std::size_t = 0UL, const long * = nullptr, const double * = nullptr);
+
+    APIGObjective(const SparseOp &, const DOCIWfn &,
+                    const pybind11::object, const pybind11::object,
+                    const pybind11::object, const pybind11::object);
+
+    APIGObjective(const APIGObjective &);
+
+    APIGObjective(APIGObjective &&) noexcept;
+
+    void init_overlap(const DOCIWfn &);
+
+    virtual void overlap(const size_t, const double *x, double *y);
+
+    virtual void d_overlap(const size_t, const double *x, double *y);
+};
+
 } // namespace pyci

--- a/pyci/src/SpookyV2.cpp
+++ b/pyci/src/SpookyV2.cpp
@@ -1,0 +1,351 @@
+// Spooky Hash
+// A 128-bit noncryptographic hash, for checksums and table lookup
+// By Bob Jenkins.  Public domain.
+//   Oct 31 2010: published framework, disclaimer ShortHash isn't right
+//   Nov 7 2010: disabled ShortHash
+//   Oct 31 2011: replace End, ShortMix, ShortEnd, enable ShortHash again
+//   April 10 2012: buffer overflow on platforms without unaligned reads
+//   July 12 2012: was passing out variables in final to in/out in short
+//   July 30 2012: I reintroduced the buffer overflow
+//   August 5 2012: SpookyV2: d = should be d += in short hash, and remove extra mix from long hash
+
+#include <memory.h>
+#include "SpookyV2.h"
+
+#define ALLOW_UNALIGNED_READS 1
+
+//
+// short hash ... it could be used on any message, 
+// but it's used by Spooky just for short messages.
+//
+void SpookyHash::Short(
+    const void *message,
+    size_t length,
+    uint64 *hash1,
+    uint64 *hash2)
+{
+    uint64 buf[2*sc_numVars];
+    union 
+    { 
+        const uint8 *p8; 
+        uint32 *p32;
+        uint64 *p64; 
+        size_t i; 
+    } u;
+
+    u.p8 = (const uint8 *)message;
+    
+    if (!ALLOW_UNALIGNED_READS && (u.i & 0x7))
+    {
+        memcpy(buf, message, length);
+        u.p64 = buf;
+    }
+
+    size_t remainder = length%32;
+    uint64 a=*hash1;
+    uint64 b=*hash2;
+    uint64 c=sc_const;
+    uint64 d=sc_const;
+
+    if (length > 15)
+    {
+        const uint64 *end = u.p64 + (length/32)*4;
+        
+        // handle all complete sets of 32 bytes
+        for (; u.p64 < end; u.p64 += 4)
+        {
+            c += u.p64[0];
+            d += u.p64[1];
+            ShortMix(a,b,c,d);
+            a += u.p64[2];
+            b += u.p64[3];
+        }
+        
+        //Handle the case of 16+ remaining bytes.
+        if (remainder >= 16)
+        {
+            c += u.p64[0];
+            d += u.p64[1];
+            ShortMix(a,b,c,d);
+            u.p64 += 2;
+            remainder -= 16;
+        }
+    }
+    
+    // Handle the last 0..15 bytes, and its length
+    d += ((uint64)length) << 56;
+    switch (remainder)
+    {
+    case 15:
+    d += ((uint64)u.p8[14]) << 48;
+    case 14:
+        d += ((uint64)u.p8[13]) << 40;
+    case 13:
+        d += ((uint64)u.p8[12]) << 32;
+    case 12:
+        d += u.p32[2];
+        c += u.p64[0];
+        break;
+    case 11:
+        d += ((uint64)u.p8[10]) << 16;
+    case 10:
+        d += ((uint64)u.p8[9]) << 8;
+    case 9:
+        d += (uint64)u.p8[8];
+    case 8:
+        c += u.p64[0];
+        break;
+    case 7:
+        c += ((uint64)u.p8[6]) << 48;
+    case 6:
+        c += ((uint64)u.p8[5]) << 40;
+    case 5:
+        c += ((uint64)u.p8[4]) << 32;
+    case 4:
+        c += u.p32[0];
+        break;
+    case 3:
+        c += ((uint64)u.p8[2]) << 16;
+    case 2:
+        c += ((uint64)u.p8[1]) << 8;
+    case 1:
+        c += (uint64)u.p8[0];
+        break;
+    case 0:
+        c += sc_const;
+        d += sc_const;
+    }
+    ShortEnd(a,b,c,d);
+    *hash1 = a;
+    *hash2 = b;
+}
+
+
+
+
+// do the whole hash in one call
+void SpookyHash::Hash128(
+    const void *message, 
+    size_t length, 
+    uint64 *hash1, 
+    uint64 *hash2)
+{
+    if (length < sc_bufSize)
+    {
+        Short(message, length, hash1, hash2);
+        return;
+    }
+
+    uint64 h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11;
+    uint64 buf[sc_numVars];
+    uint64 *end;
+    union 
+    { 
+        const uint8 *p8; 
+        uint64 *p64; 
+        size_t i; 
+    } u;
+    size_t remainder;
+    
+    h0=h3=h6=h9  = *hash1;
+    h1=h4=h7=h10 = *hash2;
+    h2=h5=h8=h11 = sc_const;
+    
+    u.p8 = (const uint8 *)message;
+    end = u.p64 + (length/sc_blockSize)*sc_numVars;
+
+    // handle all whole sc_blockSize blocks of bytes
+    if (ALLOW_UNALIGNED_READS || ((u.i & 0x7) == 0))
+    {
+        while (u.p64 < end)
+        { 
+            Mix(u.p64, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+	    u.p64 += sc_numVars;
+        }
+    }
+    else
+    {
+        while (u.p64 < end)
+        {
+            memcpy(buf, u.p64, sc_blockSize);
+            Mix(buf, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+	    u.p64 += sc_numVars;
+        }
+    }
+
+    // handle the last partial block of sc_blockSize bytes
+    remainder = (length - ((const uint8 *)end-(const uint8 *)message));
+    memcpy(buf, end, remainder);
+    memset(((uint8 *)buf)+remainder, 0, sc_blockSize-remainder);
+    ((uint8 *)buf)[sc_blockSize-1] = remainder;
+    
+    // do some final mixing 
+    End(buf, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+    *hash1 = h0;
+    *hash2 = h1;
+}
+
+
+
+// init spooky state
+void SpookyHash::Init(uint64 seed1, uint64 seed2)
+{
+    m_length = 0;
+    m_remainder = 0;
+    m_state[0] = seed1;
+    m_state[1] = seed2;
+}
+
+
+// add a message fragment to the state
+void SpookyHash::Update(const void *message, size_t length)
+{
+    uint64 h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11;
+    size_t newLength = length + m_remainder;
+    uint8  remainder;
+    union 
+    { 
+        const uint8 *p8; 
+        uint64 *p64; 
+        size_t i; 
+    } u;
+    const uint64 *end;
+    
+    // Is this message fragment too short?  If it is, stuff it away.
+    if (newLength < sc_bufSize)
+    {
+        memcpy(&((uint8 *)m_data)[m_remainder], message, length);
+        m_length = length + m_length;
+        m_remainder = (uint8)newLength;
+        return;
+    }
+    
+    // init the variables
+    if (m_length < sc_bufSize)
+    {
+        h0=h3=h6=h9  = m_state[0];
+        h1=h4=h7=h10 = m_state[1];
+        h2=h5=h8=h11 = sc_const;
+    }
+    else
+    {
+        h0 = m_state[0];
+        h1 = m_state[1];
+        h2 = m_state[2];
+        h3 = m_state[3];
+        h4 = m_state[4];
+        h5 = m_state[5];
+        h6 = m_state[6];
+        h7 = m_state[7];
+        h8 = m_state[8];
+        h9 = m_state[9];
+        h10 = m_state[10];
+        h11 = m_state[11];
+    }
+    m_length = length + m_length;
+    
+    // if we've got anything stuffed away, use it now
+    if (m_remainder)
+    {
+        uint8 prefix = sc_bufSize-m_remainder;
+        memcpy(&(((uint8 *)m_data)[m_remainder]), message, prefix);
+        u.p64 = m_data;
+        Mix(u.p64, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+        Mix(&u.p64[sc_numVars], h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+        u.p8 = ((const uint8 *)message) + prefix;
+        length -= prefix;
+    }
+    else
+    {
+        u.p8 = (const uint8 *)message;
+    }
+    
+    // handle all whole blocks of sc_blockSize bytes
+    end = u.p64 + (length/sc_blockSize)*sc_numVars;
+    remainder = (uint8)(length-((const uint8 *)end-u.p8));
+    if (ALLOW_UNALIGNED_READS || (u.i & 0x7) == 0)
+    {
+        while (u.p64 < end)
+        { 
+            Mix(u.p64, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+	    u.p64 += sc_numVars;
+        }
+    }
+    else
+    {
+        while (u.p64 < end)
+        { 
+            memcpy(m_data, u.p8, sc_blockSize);
+            Mix(m_data, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+	    u.p64 += sc_numVars;
+        }
+    }
+
+    // stuff away the last few bytes
+    m_remainder = remainder;
+    memcpy(m_data, end, remainder);
+    
+    // stuff away the variables
+    m_state[0] = h0;
+    m_state[1] = h1;
+    m_state[2] = h2;
+    m_state[3] = h3;
+    m_state[4] = h4;
+    m_state[5] = h5;
+    m_state[6] = h6;
+    m_state[7] = h7;
+    m_state[8] = h8;
+    m_state[9] = h9;
+    m_state[10] = h10;
+    m_state[11] = h11;
+}
+
+
+// report the hash for the concatenation of all message fragments so far
+void SpookyHash::Final(uint64 *hash1, uint64 *hash2)
+{
+    // init the variables
+    if (m_length < sc_bufSize)
+    {
+        *hash1 = m_state[0];
+        *hash2 = m_state[1];
+        Short( m_data, m_length, hash1, hash2);
+        return;
+    }
+    
+    const uint64 *data = (const uint64 *)m_data;
+    uint8 remainder = m_remainder;
+    
+    uint64 h0 = m_state[0];
+    uint64 h1 = m_state[1];
+    uint64 h2 = m_state[2];
+    uint64 h3 = m_state[3];
+    uint64 h4 = m_state[4];
+    uint64 h5 = m_state[5];
+    uint64 h6 = m_state[6];
+    uint64 h7 = m_state[7];
+    uint64 h8 = m_state[8];
+    uint64 h9 = m_state[9];
+    uint64 h10 = m_state[10];
+    uint64 h11 = m_state[11];
+
+    if (remainder >= sc_blockSize)
+    {
+        // m_data can contain two blocks; handle any whole first block
+        Mix(data, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+        data += sc_numVars;
+        remainder -= sc_blockSize;
+    }
+
+    // mix in the last partial block, and the length mod sc_blockSize
+    memset(&((uint8 *)data)[remainder], 0, (sc_blockSize-remainder));
+
+    ((uint8 *)data)[sc_blockSize-1] = remainder;
+    
+    // do some final mixing
+    End(data, h0,h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11);
+
+    *hash1 = h0;
+    *hash2 = h1;
+}
+

--- a/pyci/src/ap1rog.cpp
+++ b/pyci/src/ap1rog.cpp
@@ -1,0 +1,220 @@
+/* This file is part of PyCI.
+ *
+ * PyCI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * PyCI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PyCI. If not, see <http://www.gnu.org/licenses/>. */
+
+#include <pyci.h>
+#include <iostream>
+
+namespace pyci {
+
+AP1roGObjective::AP1roGObjective(const SparseOp &op_, const DOCIWfn &wfn_,
+                                 const std::size_t n_detcons_,
+                                 const long *idx_detcons_,
+                                 const double *val_detcons_,
+                                 const std::size_t n_paramcons_,
+                                 const long *idx_paramcons_,
+                                 const double *val_paramcons_)
+: Objective<DOCIWfn>::Objective(op_, wfn_, n_detcons_, idx_detcons_, val_detcons_, n_paramcons_, idx_paramcons_, val_paramcons_)
+{
+    init_overlap(wfn_);
+}
+
+AP1roGObjective::AP1roGObjective(const SparseOp &op_, const DOCIWfn &wfn_,
+                                 const pybind11::object idx_detcons_,
+                                 const pybind11::object val_detcons_,
+                                 const pybind11::object idx_paramcons_,
+                                 const pybind11::object val_paramcons_)
+: Objective<DOCIWfn>::Objective(op_, wfn_, idx_detcons_, val_detcons_, idx_paramcons_, val_paramcons_)
+{
+    init_overlap(wfn_);
+}
+
+AP1roGObjective::AP1roGObjective(const AP1roGObjective &obj)
+: Objective<DOCIWfn>::Objective(obj), nrow(obj.nrow), ncol(obj.ncol),
+  nexc_list(obj.nexc_list), hole_list(obj.hole_list), part_list(obj.part_list)
+{
+    return;
+}
+
+AP1roGObjective::AP1roGObjective(AP1roGObjective &&obj) noexcept
+: Objective<DOCIWfn>::Objective(obj), nrow(std::exchange(obj.nrow, 0)), ncol(std::exchange(obj.ncol, 0)),
+  nexc_list(std::move(obj.nexc_list)), hole_list(std::move(obj.hole_list)), part_list(std::move(obj.part_list))
+{
+    return;
+}
+
+void AP1roGObjective::init_overlap(const DOCIWfn &wfn_)
+{
+    nparam = wfn_.nocc_up * (wfn_.nbasis - wfn_.nocc_up);
+    nrow = wfn_.nocc_up;
+    ncol = wfn_.nbasis - wfn_.nocc_up;
+
+    ovlp.resize(nconn);
+    d_ovlp.resize(nconn * nparam);
+
+    nexc_list.resize(nconn);
+    hole_list.resize(wfn_.nocc_up * nconn);
+    part_list.resize(wfn_.nocc_up * nconn);
+
+    std::size_t nword = (ulong)wfn_.nword;
+    for (std::size_t idet = 0; idet != nconn; ++idet) {
+        std::vector<ulong> rdet(wfn_.nword);
+        fill_hartreefock_det(wfn_.nocc_up, &rdet[0]);
+        const ulong *det = wfn_.det_ptr(idet);
+        ulong word, hword, pword;
+        std::size_t h, p, nexc = 0;
+        for (std::size_t iword = 0; iword != nword; ++iword) {
+            word = rdet[iword] ^ det[iword];
+            hword = word & rdet[iword];
+            pword = word & det[iword];
+            while (hword) {
+                h = Ctz(hword);
+                p = Ctz(pword);
+                hole_list[idet * wfn_.nocc_up + nexc] = h + iword * Size<ulong>();
+                part_list[idet * wfn_.nocc_up + nexc] = p + iword * Size<ulong>() - wfn_.nocc_up;
+                hword &= ~(1UL << h);
+                pword &= ~(1UL << p);
+                ++nexc;
+            }
+        }
+        nexc_list[idet] = nexc;
+    }
+}
+
+void AP1roGObjective::overlap(const size_t ndet, const double *x, double *y) {
+
+    std::size_t m, i, j, k, c;
+    std::size_t *hlist, *plist;
+    double rowsum, rowsumprod, out;
+
+    for (std::size_t idet = 0; idet != ndet; ++idet) {
+
+        m = nexc_list[idet];
+        if (m == 0) {
+            y[idet] = 1;
+            continue;
+        }
+
+        hlist = &hole_list[idet * nrow];
+        plist = &part_list[idet * nrow];
+
+        out = 0;
+
+        /* Iterate over c = pow(2, m) submatrices (equal to (1 << m)) submatrices. */
+        c = 1UL << m;
+
+        /* Loop over columns of submatrix; compute product of row sums. */
+        for (k = 0; k < c; ++k) {
+            rowsumprod = 1.0;
+            for (i = 0; i < m; ++i) {
+
+                /* Loop over rows of submatrix; compute row sum. */
+                rowsum = 0.0;
+                for (j = 0; j < m; ++j) {
+
+                    /* Add element to row sum if the row index is in the characteristic *
+                     * vector of the submatrix, which is the binary vector given by k.  */
+                    if (k & (1UL << j)) {
+                        rowsum += x[ncol * hlist[i] + plist[j]];
+                    }
+                }
+
+                /* Update product of row sums. */
+                rowsumprod *= rowsum;
+            }
+
+            /* Add term multiplied by the parity of the characteristic vector. */
+            out += rowsumprod * (1 - ((__builtin_popcountll(k) & 1) << 1));
+        }
+
+        /* Return answer with the correct sign (times -1 for odd m). */
+        y[idet] = out * ((m % 2 == 1) ? -1 : 1);
+    }
+}
+
+void AP1roGObjective::d_overlap(const size_t ndet, const double *x, double *y) {
+
+    std::size_t m, n, i, j, k, c;
+    std::size_t *hlist, *plist;
+    double rowsum, rowsumprod, out;
+
+    for (std::size_t idet = 0; idet != ndet; ++idet) {
+
+        for (std::size_t iparam = 0; iparam != nparam; ++iparam) {
+
+            hlist = &hole_list[idet * nrow];
+            plist = &part_list[idet * nrow];
+
+            m = nexc_list[idet];
+            if (m == 0) {
+                y[ndet * iparam + idet] = 0;
+                continue;
+            }
+
+            std::vector<std::size_t> rows;
+            std::vector<std::size_t> cols;
+            for (i = 0; i < m; ++i) {
+                if (hlist[i] != iparam / ncol) {
+                    rows.push_back(hlist[i]);
+                }
+                if (plist[i] != iparam % ncol) {
+                    cols.push_back(plist[i]);
+                }
+            }
+            m = rows.size();
+            n = cols.size();
+            if (m == 0 && n == 0) {
+                y[ndet * iparam + idet] = 1;
+                continue;
+            } else if (m == nexc_list[idet] || n == nexc_list[idet] || m != n) {
+                y[ndet * iparam + idet] = 0;
+                continue;
+            }
+
+            out = 0;
+
+            /* Iterate over c = pow(2, m) submatrices (equal to (1 << m)) submatrices. */
+            c = 1UL << m;
+
+            /* Loop over columns of submatrix; compute product of row sums. */
+            for (k = 0; k < c; ++k) {
+                rowsumprod = 1.0;
+                for (i = 0; i < m; ++i) {
+
+                    /* Loop over rows of submatrix; compute row sum. */
+                    rowsum = 0.0;
+                    for (j = 0; j < m; ++j) {
+
+                        /* Add element to row sum if the row index is in the characteristic *
+                         * vector of the submatrix, which is the binary vector given by k.  */
+                        if (k & (1UL << j)) {
+                            rowsum += x[ncol * rows[i] + cols[j]];
+                        }
+                    }
+
+                    /* Update product of row sums. */
+                    rowsumprod *= rowsum;
+                }
+
+                /* Add term multiplied by the parity of the characteristic vector. */
+                out += rowsumprod * (1 - ((__builtin_popcountll(k) & 1) << 1));
+            }
+
+            /* Return answer with the correct sign (times -1 for odd m). */
+            y[ndet * iparam + idet] = out * ((m % 2 == 1) ? -1 : 1);
+        }
+    }
+}
+
+} // namespace pyci

--- a/pyci/src/apig.cpp
+++ b/pyci/src/apig.cpp
@@ -1,0 +1,195 @@
+/* This file is part of PyCI.
+ *
+ * PyCI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * PyCI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PyCI. If not, see <http://www.gnu.org/licenses/>. */
+
+#include <pyci.h>
+#include <iostream>
+
+namespace pyci {
+
+APIGObjective::APIGObjective(const SparseOp &op_, const DOCIWfn &wfn_,
+                                 const std::size_t n_detcons_,
+                                 const long *idx_detcons_,
+                                 const double *val_detcons_,
+                                 const std::size_t n_paramcons_,
+                                 const long *idx_paramcons_,
+                                 const double *val_paramcons_)
+: Objective<DOCIWfn>::Objective(op_, wfn_, n_detcons_, idx_detcons_, val_detcons_, n_paramcons_, idx_paramcons_, val_paramcons_)
+{
+    init_overlap(wfn_);
+}
+
+APIGObjective::APIGObjective(const SparseOp &op_, const DOCIWfn &wfn_,
+                                 const pybind11::object idx_detcons_,
+                                 const pybind11::object val_detcons_,
+                                 const pybind11::object idx_paramcons_,
+                                 const pybind11::object val_paramcons_)
+: Objective<DOCIWfn>::Objective(op_, wfn_, idx_detcons_, val_detcons_, idx_paramcons_, val_paramcons_)
+{
+    init_overlap(wfn_);
+}
+
+APIGObjective::APIGObjective(const APIGObjective &obj)
+: Objective<DOCIWfn>::Objective(obj), nrow(obj.nrow), ncol(obj.ncol), part_list(obj.part_list)
+{
+    return;
+}
+
+APIGObjective::APIGObjective(APIGObjective &&obj) noexcept
+: Objective<DOCIWfn>::Objective(obj), nrow(std::exchange(obj.nrow, 0)), ncol(std::exchange(obj.ncol, 0)),
+  part_list(std::move(obj.part_list))
+{
+    return;
+}
+
+void APIGObjective::init_overlap(const DOCIWfn &wfn_)
+{
+    nparam = wfn_.nocc_up * wfn_.nbasis;
+    nrow = wfn_.nocc_up;
+    ncol = wfn_.nbasis;
+
+    ovlp.resize(nconn);
+    d_ovlp.resize(nconn * nparam);
+
+    part_list.resize(wfn_.nocc_up * nconn);
+
+    std::size_t nword = (std::size_t)wfn_.nword;
+    for (std::size_t idet = 0; idet != nconn; ++idet) {
+        const ulong *det = wfn_.det_ptr(idet);
+        ulong word;
+        std::size_t p, nexc = 0;
+        for (std::size_t iword = 0; iword != nword; ++iword) {
+            word = det[iword];
+            while (word) {
+                p = Ctz(word);
+                part_list[idet * wfn_.nocc_up + nexc++] = p + iword * Size<ulong>();
+                word &= ~(1UL << p);
+            }
+        }
+    }
+}
+
+void APIGObjective::overlap(const size_t ndet, const double *x, double *y) {
+
+    std::size_t i, j, k, c;
+    std::size_t *plist;
+    double rowsum, rowsumprod, out;
+
+    for (std::size_t idet = 0; idet != ndet; ++idet) {
+
+        plist = &part_list[idet * nrow];
+
+        out = 0;
+
+        /* Iterate over c = pow(2, m) submatrices (equal to (1 << m)) submatrices. */
+        c = 1UL << nrow;
+
+        /* Loop over columns of submatrix; compute product of row sums. */
+        for (k = 0; k < c; ++k) {
+            rowsumprod = 1.0;
+            for (i = 0; i < nrow; ++i) {
+
+                /* Loop over rows of submatrix; compute row sum. */
+                rowsum = 0.0;
+                for (j = 0; j < nrow; ++j) {
+
+                    /* Add element to row sum if the row index is in the characteristic *
+                     * vector of the submatrix, which is the binary vector given by k.  */
+                    if (k & (1UL << j)) {
+                        // rowsum += x[nrow * plist[i] + j];
+                        rowsum += x[nrow * plist[i] + j];
+                    }
+                }
+
+                /* Update product of row sums. */
+                rowsumprod *= rowsum;
+            }
+
+            /* Add term multiplied by the parity of the characteristic vector. */
+            out += rowsumprod * (1 - ((__builtin_popcountll(k) & 1) << 1));
+        }
+
+        /* Return answer with the correct sign (times -1 for odd m). */
+        y[idet] = out * ((nrow % 2 == 1) ? -1 : 1);
+    }
+}
+
+void APIGObjective::d_overlap(const size_t ndet, const double *x, double *y) {
+
+    std::size_t m, n, i, j, k, c;
+    std::size_t *plist;
+    double rowsum, rowsumprod, out;
+
+    for (std::size_t idet = 0; idet != ndet; ++idet) {
+
+        for (std::size_t iparam = 0; iparam != nparam; ++iparam) {
+
+            plist = &part_list[idet * nrow];
+
+            std::vector<std::size_t> rows;
+            std::vector<std::size_t> cols;
+            for (i = 0; i < nrow; ++i) {
+                if (i != iparam % nrow) {
+                    rows.push_back(i);
+                }
+                if (plist[i] != iparam / nrow) {
+                    cols.push_back(plist[i]);
+                }
+            }
+            m = rows.size();
+            n = cols.size();
+            if (m == 0 && n == 0) {
+                y[ndet * iparam + idet] = 1;
+                continue;
+            } else if (m == nrow || n == nrow || m != n) {
+                y[ndet * iparam + idet] = 0;
+                continue;
+            }
+
+            out = 0;
+
+            /* Iterate over c = pow(2, m) submatrices (equal to (1 << m)) submatrices. */
+            c = 1UL << m;
+
+            /* Loop over columns of submatrix; compute product of row sums. */
+            for (k = 0; k < c; ++k) {
+                rowsumprod = 1.0;
+                for (i = 0; i < m; ++i) {
+
+                    /* Loop over rows of submatrix; compute row sum. */
+                    rowsum = 0.0;
+                    for (j = 0; j < m; ++j) {
+
+                        /* Add element to row sum if the row index is in the characteristic *
+                         * vector of the submatrix, which is the binary vector given by k.  */
+                        if (k & (1UL << j)) {
+                            rowsum += x[nrow * cols[i] + rows[j]];
+                        }
+                    }
+
+                    /* Update product of row sums. */
+                    rowsumprod *= rowsum;
+                }
+
+                /* Add term multiplied by the parity of the characteristic vector. */
+                out += rowsumprod * (1 - ((__builtin_popcountll(k) & 1) << 1));
+            }
+
+            /* Return answer with the correct sign (times -1 for odd m). */
+            y[ndet * iparam + idet] = out * ((m % 2 == 1) ? -1 : 1);
+        }
+    }
+}
+
+} // namespace pyci

--- a/pyci/src/binding.cpp
+++ b/pyci/src/binding.cpp
@@ -1330,4 +1330,86 @@ m.def("compute_enpt2", &py_compute_enpt2<FullCIWfn>, py::arg("ham"), py::arg("wf
 m.def("compute_enpt2", &py_compute_enpt2<GenCIWfn>, py::arg("ham"), py::arg("wfn"),
       py::arg("coeffs"), py::arg("energy"), py::arg("eps") = 1.0e-5, py::arg("nthread") = -1);
 
+/*
+Section: FanCI classes
+*/
+
+static constexpr char DOCSTRING_OVERLAP[] = R"""(
+)""";
+
+static constexpr char DOCSTRING_D_OVERLAP[] = R"""(
+)""";
+
+static constexpr char DOCSTRING_OBJECTIVE[] = R"""(
+)""";
+
+static constexpr char DOCSTRING_JACOBIAN[] = R"""(
+)""";
+
+py::class_<Objective<DOCIWfn>> doci_objective(m, "DOCIObjective");
+
+doci_objective.doc() = R"""(
+DOCI-FanCI objective class.
+)""";
+
+doci_objective.def("overlap", &Objective<DOCIWfn>::py_overlap, DOCSTRING_OVERLAP,
+    py::arg("x"));
+
+doci_objective.def("d_overlap", &Objective<DOCIWfn>::py_d_overlap, DOCSTRING_D_OVERLAP,
+    py::arg("x"));
+
+doci_objective.def("objective", &Objective<DOCIWfn>::py_objective, DOCSTRING_OBJECTIVE,
+    py::arg("op"), py::arg("x"));
+
+doci_objective.def("jacobian", &Objective<DOCIWfn>::py_jacobian, DOCSTRING_JACOBIAN,
+    py::arg("op"), py::arg("x"));
+
+py::class_<Objective<FullCIWfn>> fullci_objective(m, "FullCIObjective");
+
+fullci_objective.doc() = R"""(
+FullCI-FanCI objective class.
+)""";
+
+fullci_objective.def("overlap", &Objective<FullCIWfn>::py_overlap, DOCSTRING_OVERLAP,
+    py::arg("x"));
+
+fullci_objective.def("d_overlap", &Objective<FullCIWfn>::py_d_overlap, DOCSTRING_D_OVERLAP,
+    py::arg("x"));
+
+fullci_objective.def("objective", &Objective<FullCIWfn>::py_objective, DOCSTRING_OBJECTIVE,
+    py::arg("op"), py::arg("x"));
+
+fullci_objective.def("jacobian", &Objective<FullCIWfn>::py_jacobian, DOCSTRING_JACOBIAN,
+    py::arg("op"), py::arg("x"));
+
+py::class_<Objective<GenCIWfn>> genci_objective(m, "GenCIObjective");
+
+genci_objective.doc() = R"""(
+GenCI-FanCI objective class.
+)""";
+
+genci_objective.def("overlap", &Objective<GenCIWfn>::py_overlap, DOCSTRING_OVERLAP,
+    py::arg("x"));
+
+genci_objective.def("d_overlap", &Objective<GenCIWfn>::py_d_overlap, DOCSTRING_D_OVERLAP,
+    py::arg("x"));
+
+genci_objective.def("objective", &Objective<GenCIWfn>::py_objective, DOCSTRING_OBJECTIVE,
+    py::arg("op"), py::arg("x"));
+
+genci_objective.def("jacobian", &Objective<GenCIWfn>::py_jacobian, DOCSTRING_JACOBIAN,
+    py::arg("op"), py::arg("x"));
+
+py::class_<AP1roGObjective, Objective<DOCIWfn>> ap1rog_objective(m, "AP1roGObjective");
+
+ap1rog_objective.doc() = R"""(
+AP1roG objective class.
+)""";
+
+ap1rog_objective.def(py::init<const SparseOp &, const DOCIWfn &, const py::object, const py::object, const py::object, const py::object>(),
+R"""(
+)""",
+    py::arg("op"), py::arg("wfn"), py::arg("idx_det_cons") = py::none(), py::arg("det_cons") = py::none(),
+    py::arg("idx_param_cons") = py::none(), py::arg("param_cons") = py::none());
+
 END_MODULE

--- a/pyci/src/binding.cpp
+++ b/pyci/src/binding.cpp
@@ -1408,6 +1408,54 @@ AP1roG objective class.
 
 ap1rog_objective.def(py::init<const SparseOp &, const DOCIWfn &, const py::object, const py::object, const py::object, const py::object>(),
 R"""(
+Initialize the AP1roG objective instance.
+
+Parameters
+----------
+op : pyci.sparse_op
+    Sparse operator instance with ``nproj`` rows ("P" space) and ``nconn`` columns ("S" space).
+wfn : pyci.doci_wfn
+    DOCI wave function with ``nconn`` determinants.
+    The first ``nproj`` determinants should correspond to the "S" space.
+idx_det_cons : np.ndarray(Nd, dtype=pyci.c_long)
+    The indices of the determinants on which constraints should be placed.
+det_cons : np.ndarray(Nd, dtype=pyci.c_double)
+    The values to which the constrained determinants' overlaps should be equal.
+idx_param_cons : np.ndarray(Np, dtype=pyci.c_long)
+    The indices of the parameters on which constraints should be placed.
+param_cons : np.ndarray(Np, dtype=pyci.c_double)
+    The values to which the constrained parameters should be equal.
+
+)""",
+    py::arg("op"), py::arg("wfn"), py::arg("idx_det_cons") = py::none(), py::arg("det_cons") = py::none(),
+    py::arg("idx_param_cons") = py::none(), py::arg("param_cons") = py::none());
+
+py::class_<APIGObjective, Objective<DOCIWfn>> apig_objective(m, "APIGObjective");
+
+apig_objective.doc() = R"""(
+APIG objective class.
+)""";
+
+apig_objective.def(py::init<const SparseOp &, const DOCIWfn &, const py::object, const py::object, const py::object, const py::object>(),
+R"""(
+Initialize the APIG objective instance.
+
+Parameters
+----------
+op : pyci.sparse_op
+    Sparse operator instance with ``nproj`` rows ("P" space) and ``nconn`` columns ("S" space).
+wfn : pyci.doci_wfn
+    DOCI wave function with ``nconn`` determinants.
+    The first ``nproj`` determinants should correspond to the "S" space.
+idx_det_cons : np.ndarray(Nd, dtype=pyci.c_long)
+    The indices of the determinants on which constraints should be placed.
+det_cons : np.ndarray(Nd, dtype=pyci.c_double)
+    The values to which the constrained determinants' overlaps should be equal.
+idx_param_cons : np.ndarray(Np, dtype=pyci.c_long)
+    The indices of the parameters on which constraints should be placed.
+param_cons : np.ndarray(Np, dtype=pyci.c_double)
+    The values to which the constrained parameters should be equal.
+
 )""",
     py::arg("op"), py::arg("wfn"), py::arg("idx_det_cons") = py::none(), py::arg("det_cons") = py::none(),
     py::arg("idx_param_cons") = py::none(), py::arg("param_cons") = py::none());

--- a/pyci/src/common.cpp
+++ b/pyci/src/common.cpp
@@ -25,8 +25,6 @@ long gcd(long, long);
 
 long g_number_threads{1L};
 
-clhasher hasher{0x23a23cf5033c3c81UL, 0xb3816f6a2c68e530UL};
-
 long get_num_threads(void) {
     return g_number_threads;
 }

--- a/pyci/src/enpt2.cpp
+++ b/pyci/src/enpt2.cpp
@@ -17,7 +17,7 @@
 
 namespace pyci {
 
-typedef HashMap<ulong, std::pair<double, double>> PairHashMap;
+typedef HashMap<Hash, std::pair<double, double>> PairHashMap;
 
 namespace {
 
@@ -77,7 +77,7 @@ void compute_enpt2_thread_terms(const SQuantOp &ham, const FullCIWfn &wfn, PairH
                                 const double *coeffs, const double eps, const long idet,
                                 ulong *det_up, long *occs_up, long *virs_up, long *t_up) {
     long i, j, k, l, ii, jj, kk, ll, ioffset, koffset, sign_up;
-    ulong rank;
+    Hash rank;
     long n1 = wfn.nbasis;
     long n2 = n1 * n1;
     long n3 = n1 * n2;
@@ -265,7 +265,7 @@ void compute_enpt2_thread_gather(const GenCIWfn &wfn, const double *one_mo, cons
 void compute_enpt2_thread_terms(const SQuantOp &ham, const GenCIWfn &wfn, PairHashMap &terms,
                                 const double *coeffs, const double eps, const long idet, ulong *det,
                                 long *occs, long *virs, long *tmps) {
-    ulong rank;
+    Hash rank;
     long n1 = wfn.nbasis;
     long n2 = n1 * n1;
     long n3 = n1 * n2;

--- a/pyci/src/fanci.cpp
+++ b/pyci/src/fanci.cpp
@@ -1,0 +1,257 @@
+/* This file is part of PyCI.
+ *
+ * PyCI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * PyCI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PyCI. If not, see <http://www.gnu.org/licenses/>. */
+
+#include <pyci.h>
+#include <iostream>
+
+namespace pyci {
+
+template<class Wfn>
+Objective<Wfn>::Objective(const SparseOp &op_, const Wfn &wfn_,
+                          const std::size_t n_detcons_,
+                          const long *idx_detcons_,
+                          const double *val_detcons_,
+                          const std::size_t n_paramcons_,
+                          const long *idx_paramcons_,
+                          const double *val_paramcons_)
+: nproj(op_.nrow), nconn(op_.ncol), nparam(0UL), n_detcons(n_detcons_), n_paramcons(n_paramcons_)
+{
+    (void)wfn_;
+
+    init(n_detcons_, idx_detcons_, val_detcons_, n_paramcons_, idx_paramcons_, val_paramcons_);
+}
+
+template<class Wfn>
+Objective<Wfn>::Objective(const SparseOp &op_, const Wfn &wfn_,
+                          const pybind11::object idx_detcons_,
+                          const pybind11::object val_detcons_,
+                          const pybind11::object idx_paramcons_,
+                          const pybind11::object val_paramcons_)
+: nproj(op_.nrow), nconn(op_.ncol), nparam(0UL)
+{
+    (void)wfn_;
+
+    long *idxptr_detcons, *idxptr_paramcons;
+    double *valptr_detcons, *valptr_paramcons;
+
+    if (idx_detcons_.is(pybind11::none()) && val_detcons_.is(pybind11::none())) {
+        n_detcons = 0;
+        idxptr_detcons = nullptr;
+        valptr_detcons = nullptr;
+    } else if (!(idx_detcons_.is(pybind11::none()) || val_detcons_.is(pybind11::none()))) {
+        pybind11::buffer_info idx_detcons_info = idx_detcons_.cast<Array<long>>().request();
+        pybind11::buffer_info val_detcons_info = val_detcons_.cast<Array<double>>().request();
+        n_detcons = 1;
+        for (pybind11::ssize_t dim : idx_detcons_info.shape)
+            n_detcons *= dim;
+        idxptr_detcons = reinterpret_cast<long *>(idx_detcons_info.ptr);
+        valptr_detcons = reinterpret_cast<double *>(val_detcons_info.ptr);
+    } else {
+        throw std::exception();
+    }
+
+    if (idx_paramcons_.is(pybind11::none()) && val_paramcons_.is(pybind11::none())) {
+        n_paramcons = 0;
+        idxptr_paramcons = nullptr;
+        valptr_paramcons = nullptr;
+    } else if (!(idx_paramcons_.is(pybind11::none()) || val_paramcons_.is(pybind11::none()))) {
+        pybind11::buffer_info idx_paramcons_info = idx_paramcons_.cast<Array<long>>().request();
+        pybind11::buffer_info val_paramcons_info = val_paramcons_.cast<Array<double>>().request();
+        n_paramcons = 1;
+        for (pybind11::ssize_t dim : idx_paramcons_info.shape)
+            n_paramcons *= dim;
+        idxptr_paramcons = reinterpret_cast<long *>(idx_paramcons_info.ptr);
+        valptr_paramcons = reinterpret_cast<double *>(val_paramcons_info.ptr);
+    } else {
+        throw std::exception();
+    }
+    init(n_detcons, idxptr_detcons, valptr_detcons, n_paramcons, idxptr_paramcons, valptr_paramcons);
+}
+
+template<class Wfn>
+Objective<Wfn>::Objective(const Objective<Wfn> &obj)
+: nproj(obj.nproj), nconn(obj.nconn), nparam(obj.nparam), n_detcons(obj.n_detcons),
+  n_paramcons(obj.n_paramcons), ovlp(obj.ovlp), d_ovlp(obj.d_ovlp), idx_detcons(obj.idx_detcons),
+  idx_paramcons(obj.idx_paramcons), val_detcons(obj.val_detcons), val_paramcons(obj.val_paramcons)
+{
+    return;
+}
+
+template<class Wfn>
+Objective<Wfn>::Objective(Objective<Wfn> &&obj) noexcept
+: nproj(std::exchange(obj.nproj, 0)), nconn(std::exchange(obj.nconn, 0)), nparam(std::exchange(obj.nparam, 0)), n_detcons(std::exchange(obj.n_detcons, 0)),
+  n_paramcons(std::exchange(obj.n_paramcons, 0)), ovlp(std::move(obj.ovlp)), d_ovlp(std::move(obj.d_ovlp)), idx_detcons(std::move(obj.idx_detcons)),
+  idx_paramcons(std::move(obj.idx_paramcons)), val_detcons(std::move(obj.val_detcons)), val_paramcons(std::move(obj.val_paramcons))
+{
+    return;
+}
+
+template<class Wfn>
+void Objective<Wfn>::init(const std::size_t n_detcons_,
+                          const long *idx_detcons_,
+                          const double *val_detcons_,
+                          const std::size_t n_paramcons_,
+                          const long *idx_paramcons_,
+                          const double *val_paramcons_)
+{
+    if (n_detcons_ != 0) {
+        idx_detcons.resize(n_detcons_);
+        val_detcons.resize(n_detcons_);
+        for (size_t i = 0; i != n_detcons_; ++i) {
+            idx_detcons[i] = idx_detcons_[i];
+            val_detcons[i] = val_detcons_[i];
+        }
+    }
+
+    if (n_paramcons_ != 0) {
+        idx_paramcons.resize(n_paramcons_);
+        val_paramcons.resize(n_paramcons_);
+        for (std::size_t i = 0; i != n_paramcons_; ++i) {
+            idx_paramcons[i] = idx_paramcons_[i];
+            val_paramcons[i] = val_paramcons_[i];
+        }
+    }
+}
+
+template<class Wfn>
+void Objective<Wfn>::objective(const SparseOp &op, const double *x, double *y)
+{
+    double e = x[nparam];
+
+    /* Compute overlaps of determinants in connection space ("S space"):
+
+           c_m
+    */
+    this->overlap(nconn, x, &ovlp[0]);
+
+    /* Compute objective function:
+
+           f_n = <m|H|n> c_m - E <n|\Psi>
+    */
+    op.perform_op(&ovlp[0], y);
+    for (std::size_t i = 0; i != nproj; ++i) {
+        y[i] -= e * ovlp[i];
+    }
+    y += nproj;
+
+    /* Compute determinant constraints */
+    for (std::size_t i = 0; i != n_detcons; ++i) {
+        y[i] = ovlp[idx_detcons[i]] - val_detcons[i];
+    }
+    y += n_detcons;
+
+    /* Compute parameter constraints. */
+    for (std::size_t i = 0; i != n_paramcons; ++i) {
+        y[i] = x[idx_paramcons[i]] - val_paramcons[i];
+    }
+}
+
+template<class Wfn>
+void Objective<Wfn>::jacobian(const SparseOp &op, const double *x, double *y)
+{
+    double e = x[nparam];
+
+    /* Compute overlaps of determinants in projection space ("P space"):
+
+           c_n
+    */
+    this->overlap(nproj, x, &ovlp[0]);
+
+    /* Compute gradient of overlaps of determinants in connection space ("S space"):
+
+           d(c_m)/d(p_k)
+    */
+    this->d_overlap(nconn, x, &d_ovlp[0]);
+
+    /* Compute determinant constraint gradients */
+    for (std::size_t j = 0, i; j != n_detcons; ++j) {
+        for (i = 0; i != nparam; ++i) {
+            y[(nproj + n_detcons + n_paramcons) * i + nproj + j] = d_ovlp[nconn * i + idx_detcons[j]];
+        }
+    }
+
+    /* Compute parameter constraint gradients. */
+    for (std::size_t i = 0; i != n_paramcons; ++i) {
+        y[(nproj + n_detcons + n_paramcons) * idx_paramcons[i] + nproj + n_detcons + i] = 1;
+    }
+
+    /* Compute each column of the Jacobian:
+
+           d(<n|H|\Psi>)/d(p_k) = <m|H|n> d(c_m)/d(p_k)
+
+           E d(<n|\Psi>)/d(p_k) = E \delta_{nk} d(c_n)/d(p_k)
+    */
+    double *d_ovlp_col = &d_ovlp[0];
+    for (std::size_t i = 0, j; i != nparam; ++i) {
+        op.perform_op(d_ovlp_col, y);
+        for (j = 0; j != nproj; ++j) {
+            y[j] -= e * d_ovlp_col[j];
+        }
+        d_ovlp_col += nconn;
+        y += nproj + n_detcons + n_paramcons;
+    }
+
+    /* Compute final Jacobian column:
+
+           dE/d(p_k) <n|\Psi> = dE/d(p_k) \delta_{nk} c_n
+    */
+    for (std::size_t i = 0; i != nproj; ++i) {
+        y[i] = -ovlp[i];
+    }
+}
+
+template<class Wfn>
+Array<double> Objective<Wfn>::py_objective(const SparseOp &op, const Array<double> &x)
+{
+    Array<double> y(nproj + n_detcons + n_paramcons);
+    objective(op, reinterpret_cast<const double *>(x.request().ptr),
+              reinterpret_cast<double *>(y.request().ptr));
+    return y;
+}
+
+template<class Wfn>
+ColMajorArray<double> Objective<Wfn>::py_jacobian(const SparseOp &op, const Array<double> &x)
+{
+    ColMajorArray<double> y({(long)(nproj + n_detcons + n_paramcons), (long)nparam + 1});
+    jacobian(op, reinterpret_cast<const double *>(x.request().ptr),
+             reinterpret_cast<double *>(y.request().ptr));
+    return y;
+}
+
+template<class Wfn>
+Array<double> Objective<Wfn>::py_overlap(const Array<double> &x)
+{
+    Array<double> y(nconn);
+    this->overlap(nconn, reinterpret_cast<const double *>(x.request().ptr),
+              reinterpret_cast<double *>(y.request().ptr));
+    return y;
+}
+
+template<class Wfn>
+ColMajorArray<double> Objective<Wfn>::py_d_overlap(const Array<double> &x)
+{
+    ColMajorArray<double> y({nconn, nparam});
+    this->d_overlap(nconn, reinterpret_cast<const double *>(x.request().ptr),
+              reinterpret_cast<double *>(y.request().ptr));
+    return y;
+}
+
+template class Objective<DOCIWfn>;
+
+template class Objective<FullCIWfn>;
+
+template class Objective<GenCIWfn>;
+
+} // namespace pyci

--- a/pyci/src/hci.cpp
+++ b/pyci/src/hci.cpp
@@ -21,7 +21,7 @@ namespace {
 
 void hci_thread_add_dets(const SQuantOp &ham, const DOCIWfn &wfn, DOCIWfn &t_wfn, const double *coeffs,
                          const double eps, const long idet, ulong *det, long *occs, long *virs) {
-    ulong rank;
+    Hash rank;
     // fill working vectors
     wfn.copy_det(idet, det);
     fill_occs(wfn.nword, det, occs);
@@ -47,7 +47,7 @@ void hci_thread_add_dets(const SQuantOp &ham, const FullCIWfn &wfn, FullCIWfn &t
                          const double *coeffs, const double eps, const long idet, ulong *det_up,
                          long *occs_up, long *virs_up) {
     long i, j, k, l, ii, jj, kk, ll, ioffset, koffset;
-    ulong rank;
+    Hash rank;
     long n1 = wfn.nbasis;
     long n2 = n1 * n1;
     long n3 = n1 * n2;
@@ -179,7 +179,7 @@ void hci_thread_add_dets(const SQuantOp &ham, const FullCIWfn &wfn, FullCIWfn &t
 
 void hci_thread_add_dets(const SQuantOp &ham, const GenCIWfn &wfn, GenCIWfn &t_wfn, const double *coeffs,
                          const double eps, const long idet, ulong *det, long *occs, long *virs) {
-    ulong rank;
+    Hash rank;
     long n1 = wfn.nbasis;
     long n2 = n1 * n1;
     long n3 = n1 * n2;

--- a/pyci/src/onespinwfn.cpp
+++ b/pyci/src/onespinwfn.cpp
@@ -125,7 +125,7 @@ long OneSpinWfn::index_det(const ulong *det) const {
     return (search == dict.end()) ? -1 : search->second;
 }
 
-long OneSpinWfn::index_det_from_rank(const ulong rank) const {
+long OneSpinWfn::index_det_from_rank(const Hash rank) const {
     const auto &search = dict.find(rank);
     return (search == dict.end()) ? -1 : search->second;
 }
@@ -134,8 +134,8 @@ void OneSpinWfn::copy_det(const long i, ulong *det) const {
     std::memcpy(det, &dets[i * nword], sizeof(ulong) * nword);
 }
 
-ulong OneSpinWfn::rank_det(const ulong *det) const {
-    return hasher.operator()<ulong>(det, nword);
+Hash OneSpinWfn::rank_det(const ulong *det) const {
+    return spookyhash(nword, det);
 }
 
 long OneSpinWfn::add_det(const ulong *det) {
@@ -147,7 +147,7 @@ long OneSpinWfn::add_det(const ulong *det) {
     return -1;
 }
 
-long OneSpinWfn::add_det_with_rank(const ulong *det, const ulong rank) {
+long OneSpinWfn::add_det_with_rank(const ulong *det, const Hash rank) {
     if (dict.insert(std::make_pair(rank, ndet)).second) {
         dets.resize(dets.size() + nword);
         std::memcpy(&dets[nword * ndet], det, sizeof(ulong) * nword);
@@ -288,7 +288,7 @@ long OneSpinWfn::py_index_det(const Array<ulong> det) const {
     return index_det(reinterpret_cast<const ulong *>(det.request().ptr));
 }
 
-ulong OneSpinWfn::py_rank_det(const Array<ulong> det) const {
+Hash OneSpinWfn::py_rank_det(const Array<ulong> det) const {
     return rank_det(reinterpret_cast<const ulong *>(det.request().ptr));
 }
 

--- a/pyci/src/twospinwfn.cpp
+++ b/pyci/src/twospinwfn.cpp
@@ -131,7 +131,7 @@ long TwoSpinWfn::index_det(const ulong *det) const {
     return (search == dict.end()) ? -1 : search->second;
 }
 
-long TwoSpinWfn::index_det_from_rank(const ulong rank) const {
+long TwoSpinWfn::index_det_from_rank(const Hash rank) const {
     const auto &search = dict.find(rank);
     return (search == dict.end()) ? -1 : search->second;
 }
@@ -140,8 +140,8 @@ void TwoSpinWfn::copy_det(const long i, ulong *det) const {
     std::memcpy(det, &dets[i * nword2], sizeof(ulong) * nword2);
 }
 
-ulong TwoSpinWfn::rank_det(const ulong *det) const {
-    return hasher.operator()<ulong>(det, nword2);
+Hash TwoSpinWfn::rank_det(const ulong *det) const {
+    return spookyhash(nword2, det);
 }
 
 long TwoSpinWfn::add_det(const ulong *det) {
@@ -153,7 +153,7 @@ long TwoSpinWfn::add_det(const ulong *det) {
     return -1;
 }
 
-long TwoSpinWfn::add_det_with_rank(const ulong *det, const ulong rank) {
+long TwoSpinWfn::add_det_with_rank(const ulong *det, const Hash rank) {
     if (dict.insert(std::make_pair(rank, ndet)).second) {
         dets.resize(dets.size() + nword2);
         std::memcpy(&dets[nword2 * ndet], det, sizeof(ulong) * nword2);
@@ -312,7 +312,7 @@ long TwoSpinWfn::py_index_det(const Array<ulong> det) const {
     return index_det(reinterpret_cast<const ulong *>(det.request().ptr));
 }
 
-ulong TwoSpinWfn::py_rank_det(const Array<ulong> det) const {
+Hash TwoSpinWfn::py_rank_det(const Array<ulong> det) const {
     return rank_det(reinterpret_cast<const ulong *>(det.request().ptr));
 }
 

--- a/website/install.rst
+++ b/website/install.rst
@@ -48,9 +48,12 @@ Some header-only C++ libraries are downloaded automatically:
 -  `Parallel Hashmap`__
 -  Pybind11_
 -  Spectra_
--  CLHash_
 
 __ Parallel-Hashmap_
+
+Some public domain C++ libraries are included directly with the source code:
+
+-  SpookyHash_
 
 Install dependencies
 ====================
@@ -119,7 +122,6 @@ Then, after building PyCI, run the following to build the HTML documentation:
     cd doc && make html
 
 .. _`Clang/LLVM`:       http://clang.llvm.org/
-.. _CLHash:             https://github.com/lemire/clhash/
 .. _Eigen:              http://eigen.tuxfamily.org/
 .. _GCC:                http://gcc.gnu.org/
 .. _Git:                http://git-scm.com/
@@ -137,3 +139,4 @@ Then, after building PyCI, run the following to build the HTML documentation:
 .. _Spectra:            http://spectralib.org/
 .. _Sphinx-RTD-Theme:   http://sphinx-rtd-theme.readthedocs.io/
 .. _Sphinx:             http://sphinx-doc.org/
+.. _SpookyHash:         http://burtleburtle.net/bob/hash/spooky.html


### PR DESCRIPTION
Added a C++ version of the FanCI module. Supports AP1roG.

This works by providing the `wfn` and the `sparse_op` to the FanCI instance. I'm thinking about how to handle the initialization... should we do it in Python, or should this also be done in C++?  I lean towards Python.

@PaulWAyers @gabrielasd 