### PR TITLE
Updated optimize function to accept user customized optimizers

### DIFF
--- a/pyci/fanci/fanci.py
+++ b/pyci/fanci/fanci.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
 
 import numpy as np
 
-from scipy.optimize import OptimizeResult, least_squares, root,minimize
+from scipy.optimize import OptimizeResult, least_squares, root, minimize
 
 import pyci
 
@@ -50,6 +50,7 @@ class FanCI(metaclass=ABCMeta):
 
         """
         return self._nparam
+
     @property
     def constraints(self) -> Tuple[str]:
         r"""
@@ -181,7 +182,9 @@ class FanCI(metaclass=ABCMeta):
         elif isinstance(constraints, dict):
             constraints = OrderedDict(constraints)
         else:
-            raise TypeError(f"Invalid `constraints` type `{type(constraints)}`; must be dictionary")
+            raise TypeError(
+                f"Invalid `constraints` type `{type(constraints)}`; must be dictionary"
+            )
 
         # Add norm_det and norm_param constraints
         norm_param = list() if norm_param is None else norm_param
@@ -227,7 +230,7 @@ class FanCI(metaclass=ABCMeta):
         mode: str = "lstsq",
         use_jac: bool = False,
         sigma: float = 0.1,
-	    custom_optimizer: callable=None,
+        custom_optimizer: callable = None,
         **kwargs: Any,
     ) -> OptimizeResult:
         r"""
@@ -237,7 +240,7 @@ class FanCI(metaclass=ABCMeta):
         ----------
         x0 : np.ndarray
             Initial guess for wave function parameters.
-        mode : ('lstsq' | 'root' | 'custom'), default='lstsq'
+        mode : ('lstsq' | 'root' | 'custom_scalar' | 'custom_vectorial'), default='lstsq'
             Solver mode.
         use_jac : bool, default=False
             Whether to use the Jacobian function or a finite-difference approximation.
@@ -264,7 +267,7 @@ class FanCI(metaclass=ABCMeta):
         opt_kwargs = kwargs.copy()
         if use_jac:
             opt_kwargs["jac"] = j
-            
+
         # Parse mode parameter; choose optimizer and fix arguments
         if mode == "lstsq":
             optimizer = least_squares
@@ -272,14 +275,23 @@ class FanCI(metaclass=ABCMeta):
         elif mode == "root":
             optimizer = root
             opt_args = f, x0
-        elif mode == 'custom':
+        elif mode == "custom_vectorial":
             if custom_optimizer is None:
                 raise ValueError("Optimizer is not provided")
             optimizer = custom_optimizer
             opt_args = f, x0
+        elif mode == "custom_scalar":
+            if custom_optimizer is None:
+                raise ValueError("Optimizer is not provided")
+            optimizer = custom_optimizer
+            f_scalar = lambda x: np.sum(f(x) ** 2)
+            opt_args = f_scalar, x0
+            if use_jac:
+                j_scalar = lambda x: 2 * f(x) @ j(x)
+                opt_kwargs["jac"] = j_scalar
         else:
             raise ValueError("invalid mode parameter")
-        
+
         # Run optimizer
         return optimizer(*opt_args, **opt_kwargs)
 
@@ -598,13 +610,15 @@ class FanCI(metaclass=ABCMeta):
             """
             y = np.zeros(self._nparam, dtype=pyci.c_double)
             d_ovlp = self.compute_overlap_deriv(x[:-1], self._sspace[np.newaxis, i])[0]
-            y[: -1] = d_ovlp
+            y[:-1] = d_ovlp
             return y
 
         return f, dfdx
 
     @abstractmethod
-    def compute_overlap(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
+    def compute_overlap(
+        self, x: np.ndarray, occs_array: Union[np.ndarray, str]
+    ) -> np.ndarray:
         r"""
         Compute the FanCI overlap vector.
 
@@ -679,7 +693,9 @@ def fill_wavefunction(wfn: pyci.wavefunction, nproj: int, fill: str) -> None:
         s_max = min(wfn.nocc_up, wfn.nvir_up)
         connections = (1, 2)
     else:
-        raise TypeError(f"invalid `wfn` type `{type(wfn)}`; must be `pyci.wavefunction`")
+        raise TypeError(
+            f"invalid `wfn` type `{type(wfn)}`; must be `pyci.wavefunction`"
+        )
 
     # Use new wavefunction; don't modify original object
     wfn = wfn.__class__(wfn)
@@ -711,7 +727,9 @@ def fill_wavefunction(wfn: pyci.wavefunction, nproj: int, fill: str) -> None:
 
     # Truncate wave function if we generated > nproj determinants
     if len(wfn) > nproj:
-        wfn = wfn.__class__(wfn.nbasis, wfn.nocc_up, wfn.nocc_dn, wfn.to_det_array(nproj))
+        wfn = wfn.__class__(
+            wfn.nbasis, wfn.nocc_up, wfn.nocc_dn, wfn.to_det_array(nproj)
+        )
 
     # Fill wfn with S space determinants
     for det in wfn.to_det_array(nproj):

--- a/pyci/fanci/fanci.py
+++ b/pyci/fanci/fanci.py
@@ -240,7 +240,7 @@ class FanCI(metaclass=ABCMeta):
         ----------
         x0 : np.ndarray
             Initial guess for wave function parameters.
-        mode : ('lstsq' | 'root' | 'custom_scalar' | 'custom_vectorial'), default='lstsq'
+        mode : ('lstsq' | 'root' | 'custom_scalar' | 'custom_vector'), default='lstsq'
             Solver mode.
         use_jac : bool, default=False
             Whether to use the Jacobian function or a finite-difference approximation.
@@ -275,7 +275,7 @@ class FanCI(metaclass=ABCMeta):
         elif mode == "root":
             optimizer = root
             opt_args = f, x0
-        elif mode == "custom_vectorial":
+        elif mode == "custom_vector":
             if custom_optimizer is None:
                 raise ValueError("Optimizer is not provided")
             optimizer = custom_optimizer

--- a/pyci/fanci/test/test_objective_fanci.py
+++ b/pyci/fanci/test/test_objective_fanci.py
@@ -6,57 +6,111 @@ import numpy as np
 
 import pytest
 
-from scipy.optimize import least_squares
+import numpy.testing as npt
+
+from scipy.optimize import least_squares, minimize, fsolve
 
 import pyci
 
 from pyci.fanci import FanCI
+
 from pyci.fanci.test import find_datafile
+
+from pyci.fanci import AP1roG
 
 
 def test_fanci_init():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_add_constraint():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_remove_constraint():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_add_constraint():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_freeze_parameter():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_unfreeze_parameter():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_make_param_constraint():
-    """
-    """
+    """ """
     pass
 
 
 def test_fanci_make_det_constraint():
-    """
-    """
+    """ """
     pass
+
+
+def test_fanci_optimize():
+    filename = find_datafile("lih_hf_sto6g.fcidump")
+    ham = pyci.hamiltonian(filename)
+    e_dict = {}
+    # First compute the hartree-Fock reference energy
+    hf_wfn = pyci.doci_wfn(ham.nbasis, 2, 2)
+    hf_wfn.add_hartreefock_det()
+    hf_op = pyci.sparse_op(ham, hf_wfn)
+    e_dict["HF"] = hf_op.solve(n=1)[0][0] - ham.ecore
+
+    # Initialize AP1roG instance
+    ap1rog = AP1roG(ham, 2)
+
+    # Make initial guess
+    ap1_params = np.zeros(ap1rog.nparam, dtype=pyci.c_double)
+    ap1_params[-1] = e_dict["HF"]
+
+    # Testing optimization with least-squares
+    ap1rog_results = ap1rog.optimize(ap1_params, use_jac=True)
+    e_dict["AP1roG"] = ap1rog_results.x[-1]
+    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-7)
+
+    # Testing optimization with with root scypy function
+    ap1rog_results = ap1rog.optimize(ap1_params, use_jac=True, mode="root")
+    e_dict["AP1roG"] = ap1rog_results.x[-1]
+    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-7)
+
+    # Testing optimization with with L-BFGS-B
+    ap1rog_results = ap1rog.optimize(
+        ap1_params,
+        use_jac=True,
+        mode="custom_scalar",
+        custom_optimizer=minimize,
+        method="L-BFGS-B",
+    )
+    e_dict["AP1roG"] = ap1rog_results.x[-1]
+    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-7)
+
+    # Testing optimization with with Newton-CG
+    ap1rog_results = ap1rog.optimize(
+        ap1_params,
+        use_jac=True,
+        mode="custom_scalar",
+        custom_optimizer=minimize,
+        method="Newton-CG",
+    )
+    e_dict["AP1roG"] = ap1rog_results.x[-1]
+    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-7)
+
+    # Testing optimization with with fsolve
+    ap1rog_results = ap1rog.optimize(
+        ap1_params, use_jac=False, mode="custom_vector", custom_optimizer=fsolve
+    )
+    e_dict["AP1roG"] = ap1rog_results[-1]
+    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-7)

--- a/pyci/fanci/test/test_objective_fanci.py
+++ b/pyci/fanci/test/test_objective_fanci.py
@@ -95,7 +95,7 @@ def test_fanci_optimize():
         method="L-BFGS-B",
     )
     e_dict["AP1roG"] = ap1rog_results.x[-1]
-    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-7)
+    npt.assert_allclose(e_dict["AP1roG"], -8.963531034, rtol=0.0, atol=1.0e-6)
 
     # Testing optimization with with Newton-CG
     ap1rog_results = ap1rog.optimize(


### PR DESCRIPTION
Updated optimize function to accept user customized optimizers.
I made the test on the jupyter notebook fanci_tutorial.
I tested this implementation for least_squares and root optimizers which are already implemented to verify the output was the same. I also tested the implementation with fsolve function and it worked correctly, I just had to change some lines of code on the jupyter notebook such as
e_dict["AP1roG"] = ap1rog_results.x[-1] -------> e_dict["AP1roG"] = ap1rog_results[-1]
because the return of fsolve function does not have "x" attribute.
The implementation can not be tested on  any of the scipy.optimize.minimize function since these ones  work for the optimization of scalar functions, and Fanci object function is a vector function.