### PR TITLE
Add option to use 64-bit rapidhash for MacOS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 CFLAGS += $(shell $(PYTHON) tools/python_include_dirs.py)
 
 # Set external projects and their include directories
-DEPS := $(addprefix deps/,eigen spectra parallel-hashmap pybind11)
+DEPS := $(addprefix deps/,eigen spectra parallel-hashmap pybind11 rapidhash)
 CFLAGS += $(addprefix -Ideps/,eigen spectra/include parallel-hashmap pybind11/include)
 
 # This C++ compile flag is needed in order for Macs to find system libraries
@@ -61,6 +61,9 @@ DEFS := -D_PYCI_VERSION='$(PYCI_VERSION)'
 DEFS += -D_GIT_BRANCH='$(shell git rev-parse --abbrev-ref HEAD)'
 DEFS += -D_BUILD_TIME='$(shell date -u +%F\ %T)'
 DEFS += -D_COMPILER_VERSION='$(shell $(CXX) --version | head -n 1)'
+ifeq ($(shell uname -s),Darwin)
+DEFS += -D_USE_RAPIDHASH='1'
+endif
 
 # Set objects
 OBJECTS := $(patsubst %.cpp,%.o,$(wildcard pyci/src/*.cpp))
@@ -84,12 +87,12 @@ clean:
 cleandeps:
 	rm -rf deps
 
+.PHONY: compile_flags.txt
+compile_flags.txt:
+	echo "$(CFLAGS)" | tr ' ' '\n' > $(@)
 
 # Make targets
 # ------------
-
-compile_flags.txt:
-	echo "$(CFLAGS)" | tr ' ' '\n' > $(@)
 
 pyci/src/%.o: pyci/src/%.cpp pyci/include/pyci.h $(DEPS)
 	$(CXX) $(CFLAGS) $(DEFS) -c $(<) -o $(@)
@@ -114,3 +117,6 @@ deps/parallel-hashmap:
 
 deps/pybind11:
 	[ -d $@ ] || git clone https://github.com/pybind/pybind11.git $@
+
+deps/rapidhash:
+	[ -d $@ ] || git clone https://github.com/nicoshev/rapidhash.git $@


### PR DESCRIPTION
Uses 64-bit rapidhash implementation instead of 128-bit spookyhash. For playing around on a Mac laptop, this should be fine.

Sets up spookyhash or rapidhash based on whether
the command `uname -s` outputs 'Darwin' (the MacOS kernel).