### PR TITLE
 Fix enpt2

### DIFF
--- a/pyci/test/test_routines.py
+++ b/pyci/test/test_routines.py
@@ -473,12 +473,12 @@ def test_run_hci(filename, wfn_type, occs, energy):
 @pytest.mark.parametrize(
     "filename, wfn_type, occs, energy",
     [
-        ("he_ccpvqz", pyci.fullci_wfn, (1, 1), -2.964248588),
-        ("li2_ccpvdz", pyci.doci_wfn, (3, 3), -14.881173703),
-        ("be_ccpvdz", pyci.doci_wfn, (2, 2), -14.603138756),
-        ("he_ccpvqz", pyci.doci_wfn, (1, 1), -2.964248588),
-        ("be_ccpvdz", pyci.fullci_wfn, (2, 2), -14.617423859),
-        ("h2o_ccpvdz", pyci.doci_wfn, (5, 5), -75.784506748),
+        ("he_ccpvqz", pyci.fullci_wfn, (1, 1), -2.903862702173526),
+        ("li2_ccpvdz", pyci.doci_wfn, (3, 3), -14.90042952400693),
+        ("be_ccpvdz", pyci.doci_wfn, (2, 2), -14.61920612157886),
+        ("he_ccpvqz", pyci.doci_wfn, (1, 1), -2.903862702173526),
+        ("be_ccpvdz", pyci.fullci_wfn, (2, 2), -14.61740346031583),
+        ("h2o_ccpvdz", pyci.doci_wfn, (5, 5), -76.04227376501808),
     ],
 )
 def test_enpt2(filename, wfn_type, occs, energy):


### PR DESCRIPTION
There was a problem where the occupations in `t_up` did not match `det_up` in the 1-1 excitation elements.

Originally, the 1-0 branch had the following bit of code
```
            if (std::abs(val) > eps) {
                rank = wfn.rank_det(det_up);
                if (wfn.index_det_from_rank(rank) == -1) {
                    val *= sign_up;
                    fill_occs(wfn.nword, det_up, t_up);
                    compute_enpt2_thread_gather(wfn, ham.one_mo, ham.two_mo, terms[rank], val, n2,
                                                n3, t_up);
                }
            }
```
which would assign `t_up` for the 1-0 branch as needed, i.e., when |Hki*ci|>eps and when the singly-excited determinant was not contained in the variational wave function.

However, `t_up` needs to be correctly assigned also for the later 1-1 branch, which would not always happen.

Additionally, the threads are not guaranteed to join in order, so the `compute_enpt2_thread_condense` now happens only after all threads have joined.


